### PR TITLE
Hotfix/fix config file oddities

### DIFF
--- a/src/js/Config/Config.js
+++ b/src/js/Config/Config.js
@@ -2,7 +2,7 @@
 
 let envVar = ENV;
 
-let getEnvironmentVariable = (namespace, prop) => envVar && envVar[namespace] && envVar[namespace][prop] ? envVar[namespace][prop] : null;
+let getEnvironmentVariable = (namespace, prop) => envVar && envVar[namespace] && envVar[namespace][prop] !== undefined ? envVar[namespace][prop] : null;
 
 export default {
   WssURI:       getEnvironmentVariable('FR', 'WSSURI')       || 'wss://dev.api.fuelrats.com:443',

--- a/src/js/Config/Config.js
+++ b/src/js/Config/Config.js
@@ -1,6 +1,8 @@
 /* global ENV:false */
 
-let getEnvironmentVariable = (namespace, prop) => ENV && ENV[namespace] && ENV[namespace][prop] ? ENV[namespace][prop] : null;
+let envVar = ENV;
+
+let getEnvironmentVariable = (namespace, prop) => envVar && envVar[namespace] && envVar[namespace][prop] ? envVar[namespace][prop] : null;
 
 export default {
   WssURI:       getEnvironmentVariable('FR', 'WSSURI')       || 'wss://dev.api.fuelrats.com:443',


### PR DESCRIPTION
As it turns out, DefinePlugin replaces references to the global variables it defines with the object itself, meaning every reference to a DefinePlugin variable redefines the object. In hindsight, I should have expected that...

This PR also prevents possible type coercion issues once we start using boolean variables.